### PR TITLE
Changed toml for python compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,11 +8,11 @@ authors = [
 description = "Postprocessing of data sampled from internal combustion engines (Experimental, 1D/0D (Gasdyn), 3D (LibICE), etc.)"
 readme = "README.md"
 
-requires-python = ">=3.11"
+requires-python = ">=3.11 <3.12"
 dependencies = [
   'chempy >= 0.9.0',
   'pyfoam',
-  'tqdm'
+  'tqdm',
 ]
 
 classifiers = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ authors = [
 description = "Postprocessing of data sampled from internal combustion engines (Experimental, 1D/0D (Gasdyn), 3D (LibICE), etc.)"
 readme = "README.md"
 
-requires-python = ">=3.11 <3.12"
+requires-python = ">=3.11,<3.12"
 dependencies = [
   'chempy >= 0.9.0',
   'pyfoam',


### PR DESCRIPTION
python needs to be below 3.12 because no more numpy.math